### PR TITLE
Allow blocks to be passed to parser.

### DIFF
--- a/lib/ezwadl/parser.rb
+++ b/lib/ezwadl/parser.rb
@@ -14,6 +14,9 @@ module EzWadl
           add_methods(r)
           add_resources(r)
         }
+				
+        yield(top_resources) if block_given?
+        top_resources
       end
       
       private


### PR DESCRIPTION
Allow a block to be passed to the parse method so that you can perform operations
on the resources objects the parser returns.

For example:

```ruby
EzWadl::Parser.parse(File.join(Alma::WADL_DIR, 'user.wadl')) do  |rs| 
  rs.first.path = 'https://mycustompath.com'
end
```
would return the expected array of resource objects, but the first one would have a customized path. 

This will allow for simple overriding of values defined in WADLs.

Passing a block remains optional.
