### PR TITLE
Close the wadl file when done with it.

### DIFF
--- a/lib/ezwadl/parser.rb
+++ b/lib/ezwadl/parser.rb
@@ -5,7 +5,7 @@ module EzWadl
   
     class << self
       def parse(wadl)
-        doc = Nokogiri::XML open(wadl)
+        doc = File.open(wadl) { |f| Nokogiri::XML f }
         top_resources = uris(doc).map {|xml|
           Resource.new(xml)
         }


### PR DESCRIPTION
Current call leaves the handle open. Probably doesn't matter much.

(This looks like a really useful library by the way.)